### PR TITLE
fix max complains with es2015+ #7

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,11 @@ autowatch = 1
 inlets = 1
 outlets = 1
 
+// NOTE: This section must appear in any .ts file that is directuly used by a
+// [js] or [jsui] object so that tsc generates valid JS for Max.
+const module = {}
+export = {}
+
 const config = {
   outputLogs: true,
 }
@@ -16,8 +21,3 @@ setinletassist(INLET_FOO, 'Description of Inlet')
 setoutletassist(OUTLET_FOO, 'Description of Outlet')
 
 log('reloaded')
-
-// NOTE: This section must appear in any .ts file that is directuly used by a
-// [js] or [jsui] object so that tsc generates valid JS for Max.
-const module = {}
-export = {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,3 @@
 interface Function {
-  name: string;
+  readonly name: string;
 }


### PR DESCRIPTION
When  using es2015+, max would complain about not being able to find the module. 

The fix is to move the module declaration to the top of index.ts. I then found that the compiler would complain, but making the the `name` property of function readonly fixed this. 